### PR TITLE
Add support for account details endpoint

### DIFF
--- a/src/main/kotlin/Core.kt
+++ b/src/main/kotlin/Core.kt
@@ -26,6 +26,7 @@ object Core {
 
         if (parsed.verbose) {
             println("Verbose set to ${parsed.verbose}")
+            println("Using ${if (parsed.production) { "production" } else { "sandbox" } }")
             println("Config path set to ${parsed.pathToConfigFile}")
         }
 
@@ -37,7 +38,13 @@ object Core {
         }
 
         val client = Authorization(configuration, parsed.production, parsed.verbose)
-        val session = client.renewSession() ?: client.createSession()
+        val session = client.renewSession() ?: run {
+            if (parsed.verbose) {
+                println("No valid keys found, re-authorizing")
+            }
+
+            client.createSession()
+        }
 
         if (parsed.verbose) {
             session.apply {
@@ -62,6 +69,13 @@ object Core {
         accountSrvc.list()?.let {
             print("Account retrieved")
             print(it)
+
+            it.first().accountIdKey?.let {
+                accountSrvc.getBalance(it)?.let {
+                    print("Account balance")
+                    print(it)
+                }
+            }
         }
 
         // client.destroySession()

--- a/src/main/kotlin/connectors/etrade/Accounts.kt
+++ b/src/main/kotlin/connectors/etrade/Accounts.kt
@@ -1,55 +1,21 @@
 package com.seansoper.batil.connectors.etrade
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import retrofit2.converter.jackson.JacksonConverterFactory
-import java.time.Instant
-
-class Accounts(private val session: Session,
-               private val production: Boolean = false,
-               private val verbose: Boolean = false,
-               private val baseUrl: String = "https://${(if (production) "api" else "apisb")}.etrade.com") {
+class Accounts(session: Session,
+               production: Boolean? = null,
+               verbose: Boolean? = null,
+               baseUrl: String? = null): Service(session, production, verbose, baseUrl) {
 
     fun list(): List<Account>? {
-        val keys = OauthKeys(
-            consumerKey = session.consumerKey,
-            consumerSecret = session.consumerSecret,
-            accessToken = session.accessToken,
-            accessSecret = session.accessSecret,
-            verifier = session.verifier
-        )
-
-        val client = OkHttpClient.Builder()
-            .addInterceptor(HttpInterceptor(keys))
-            .addInterceptor(JsonInterceptor())
-
-        if (verbose) {
-            val logger = HttpLoggingInterceptor()
-            logger.level = HttpLoggingInterceptor.Level.BODY
-            client.addInterceptor(logger)
-        }
-
-        val module = SimpleModule()
-        module.addDeserializer(Instant::class.java, TimestampDeserializer())
-
-        val mapper = ObjectMapper()
-        mapper.registerModule(module)
-        mapper.registerModule(KotlinModule())
-
-        val retrofit = Retrofit.Builder()
-            .client(client.build())
-            .baseUrl(baseUrl)
-            .addConverterFactory(JacksonConverterFactory.create(mapper))
-            .build()
-
-        val service = retrofit.create(AccountsApi::class.java)
+        val service = createClient(AccountsApi::class.java)
         val response = service.getAccounts().execute()
 
         return response.body()?.response?.accountRoot?.accounts
     }
 
+    fun getBalance(accountIdKey: String): AccountBalance? {
+        val service = createClient(AccountsApi::class.java)
+        val response = service.getBalance(accountIdKey).execute()
+
+        return response.body()?.response
+    }
 }

--- a/src/main/kotlin/connectors/etrade/AccountsApi.kt
+++ b/src/main/kotlin/connectors/etrade/AccountsApi.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import retrofit2.Call
 import retrofit2.http.GET
+import retrofit2.http.Path
 import java.time.Instant
 
 enum class AccountMode {
@@ -16,6 +17,18 @@ enum class AccountStatus {
 
 enum class AccountType {
     AMMCHK, ARO, BCHK, BENFIRA, BENFROTHIRA, BENF_ESTATE_IRA, BENF_MINOR_IRA, BENF_ROTH_ESTATE_IRA, BENF_ROTH_MINOR_IRA, BENF_ROTH_TRUST_IRA, BENF_TRUST_IRA, BRKCD, BROKER, CASH, C_CORP, CONTRIBUTORY, COVERDELL_ESA, CONVERSION_ROTH_IRA, CREDITCARD, COMM_PROP, CONSERVATOR, CORPORATION, CSA, CUSTODIAL, DVP, ESTATE, EMPCHK, EMPMMCA, ETCHK, ETMMCHK, HEIL, HELOC, INDCHK, INDIVIDUAL, INDIVIDUAL_K, INVCLUB, INVCLUB_C_CORP, INVCLUB_LLC_C_CORP, INVCLUB_LLC_PARTNERSHIP, INVCLUB_LLC_S_CORP, INVCLUB_PARTNERSHIP, INVCLUB_S_CORP, INVCLUB_TRUST, IRA_ROLLOVER, JOINT, JTTEN, JTWROS, LLC_C_CORP, LLC_PARTNERSHIP, LLC_S_CORP, LLP, LLP_C_CORP, LLP_S_CORP, IRA, IRACD, MONEY_PURCHASE, MARGIN, MRCHK, MUTUAL_FUND, NONCUSTODIAL, NON_PROFIT, OTHER, PARTNER, PARTNERSHIP, PARTNERSHIP_C_CORP, PARTNERSHIP_S_CORP, PDT_ACCOUNT, PM_ACCOUNT, PREFCD, PREFIRACD, PROFIT_SHARING, PROPRIETARY, REGCD, ROTHIRA, ROTH_INDIVIDUAL_K, ROTH_IRA_MINORS, SARSEPIRA, S_CORP, SEPIRA, SIMPLE_IRA, TIC, TRD_IRA_MINORS, TRUST, VARCD, VARIRACD
+}
+
+enum class InstitutionType {
+    BROKERAGE, GLOBALTRADING, NONUS, STOCKPLAN, LENDING, HELOC, HEIL, ONTRACK, GENPACT, AUTO, AUTOLOAN, BETA, LOYALTY, SBASKET, CC_BALANCETRANSFER, GENPACT_LEAD, GANIS, MORTGAGE, EXTERNAL, FUTURES, VISA, RJO, WDBH
+}
+
+enum class OptionLevel {
+    NO_OPTIONS, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4
+}
+
+enum class QuoteMode {
+    QUOTE_REALTIME, QUOTE_DELAYED, QUOTE_CLOSING, QUOTE_AHT_REALTIME, QUOTE_AHT_BEFORE_OPEN, QUOTE_AHT_CLOSING, QUOTE_NONE
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -73,9 +86,100 @@ data class AccountListResponse(
     val response: AccountRoot
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class OpenCalls(
+    val minEquityCall: Float?, // The minimum equity call
+    val fedCall: Float?,       // The federal call
+    val cashCall: Float?,      // The cash call
+    val houseCall: Float?      // The house call
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class RealTimeValues(
+    val totalAccountValue: Float?, // The total account value
+    val netMv: Float?,             // The net market value
+    val netMvLong: Float?,         // The long net market value
+    val netMvShort: Float?,        // The short net market value
+    val totalLongValue: Float?,    // The total long value
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ComputedBalance(
+    val cashAvailableForInvestment: Float?,     // The cash available for investments
+    val cashAvailableForWithdrawal: Float?,     // The cash available for withdrawal
+    val totalAvailableForWithdrawal: Float?,    // The total amount available for withdrawal
+    val netCash: Float?,                        // The net cash balance
+    val cashBalance: Float?,                    // The current cash balance
+    val settledCashForInvestment: Float?,       // The settled cash for investments
+    val unSettledCashForInvestment: Float?,     // The unsettled cash for investments
+    val fundsWithheldFromPurchasePower: Float?, // The funds withheld from the purchasing power
+    val fundsWithheldFromWithdrawal: Float?,    // The funds withheld from withdrawal
+    val marginBuyingPower: Float?,              // The margin account buying power
+    val cashBuyingPower: Float?,                // The cash account buying power
+    val dtMarginBuyingPower: Float?,            // The day trader margin account buying power
+    val dtCashBuyingPower: Float?,              // The day trader cash account buying power
+    val marginBalance: Float?,                  // The margin account balance
+    val shortAdjustBalance: Float?,             // The short adjusted balance
+    val regtEquity: Float?,                     // The Regulation T equity
+    val regtEquityPercent: Float?,              // The Regulation T equity percentage
+    val accountBalance: Float?,                 // The current account balance
+
+    @JsonProperty("OpenCalls")
+    val openCalls: OpenCalls,
+
+    @JsonProperty("RealTimeValues")
+    val realTimeValues: RealTimeValues,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountCash(
+    val fundsForOpenOrdersCash: Float?, // The funds reserved for open orders
+    val moneyMktBalance: Float?,        // The current cash balance of the money market or sweep deposit account
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountBalance(
+    val accountId: String?,          // The account ID for which the balance is requested
+    val asOfDate: Int?,              // The effective date in UTC
+    val quoteMode: Int,              // The quote type indicator: 0 = QUOTE REALTIME, 1 = QUOTE DELAYED, 2 = QUOTE CLOSING, 3 = QUOTE AHT REALTIME, 4 = QUOTE AHT BEFORE OPEN, 5 = QUOTE AHT CLOSING, 6 = QUOTE NONE
+    val dayTraderStatus: String?,    // The user's status as a day trader
+    val accountMode: AccountMode?,   // The account mode indicating the account's special privileges as a cash account, a margin account, and so on
+    val accountType: AccountType?,
+    val optionLevel: OptionLevel,
+    val institutionType: InstitutionType?,
+
+    @JsonProperty("accountDescription")
+    val description: String?,
+
+    @JsonProperty("Cash")
+    val cash: AccountCash,
+
+    @JsonProperty("Computed")
+    val balances: ComputedBalance
+) {
+    val optionLevelValue: Int
+        get() {
+            return optionLevel.ordinal
+        }
+
+    val quoteModeValue: QuoteMode
+        get() {
+            return QuoteMode.values()[quoteMode]
+        }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class BalanceResponse(
+    @JsonProperty("BalanceResponse")
+    val response: AccountBalance
+)
+
 interface AccountsApi {
 
     @GET("v1/accounts/list")
     fun getAccounts(): Call<AccountListResponse>
+
+    @GET("/v1/accounts/{accountIdKey}/balance?instType=BROKERAGE&realTimeNAV=true")
+    fun getBalance(@Path("accountIdKey") accountIdKey: String): Call<BalanceResponse>
 
 }

--- a/src/main/kotlin/connectors/etrade/Market.kt
+++ b/src/main/kotlin/connectors/etrade/Market.kt
@@ -1,100 +1,35 @@
 package com.seansoper.batil.connectors.etrade
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import retrofit2.converter.jackson.JacksonConverterFactory
 import java.math.RoundingMode
 import java.text.DecimalFormat
-import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.*
 
-class Market(private val session: Session,
-             private val production: Boolean = false,
-             private val verbose: Boolean = false,
-             private val baseUrl: String = "https://${(if (production) "api" else "apisb")}.etrade.com") {
+class Market(session: Session,
+             production: Boolean? = null,
+             verbose: Boolean? = null,
+             baseUrl: String? = null): Service(session, production, verbose, baseUrl) {
 
     fun ticker(symbol: String): QuoteData? {
         return tickers(listOf(symbol))?.first()
     }
 
     fun tickers(symbols: List<String>): List<QuoteData>? {
-        val keys = OauthKeys(
-            consumerKey = session.consumerKey,
-            consumerSecret = session.consumerSecret,
-            accessToken = session.accessToken,
-            accessSecret = session.accessSecret,
-            verifier = session.verifier
-        )
-
-        val client = OkHttpClient.Builder()
-            .addInterceptor(HttpInterceptor(keys))
-            .addInterceptor(JsonInterceptor())
-
-        if (verbose) {
-            val logger = HttpLoggingInterceptor()
-            logger.level = HttpLoggingInterceptor.Level.BODY
-            client.addInterceptor(logger)
-        }
-
         val module = SimpleModule()
         module.addDeserializer(GregorianCalendar::class.java, DateTimeDeserializer())
 
-        val mapper = ObjectMapper()
-        mapper.dateFormat = SimpleDateFormat("HH:mm:ss zzz dd-MM-yyyy") // Don't think we need this
-        mapper.registerModule(module)
-        mapper.registerModule(KotlinModule())
-
-        val retrofit = Retrofit.Builder()
-            .client(client.build())
-            .baseUrl(baseUrl)
-            .addConverterFactory(JacksonConverterFactory.create(mapper))
-            .build()
-
-        val service = retrofit.create(MarketApi::class.java)
+        val service = createClient(MarketApi::class.java, module)
         val response = service.getQuote(symbols.joinToString(",")).execute()
 
         return response.body()?.response?.data
     }
 
     fun lookup(search: String): List<LookupResult>? {
-        val keys = OauthKeys(
-            consumerKey = session.consumerKey,
-            consumerSecret = session.consumerSecret,
-            accessToken = session.accessToken,
-            accessSecret = session.accessSecret,
-            verifier = session.verifier
-        )
-
-        val client = OkHttpClient.Builder()
-            .addInterceptor(HttpInterceptor(keys))
-            .addInterceptor(JsonInterceptor())
-
-        if (verbose) {
-            val logger = HttpLoggingInterceptor()
-            logger.level = HttpLoggingInterceptor.Level.BODY
-            client.addInterceptor(logger)
-        }
-
         val module = SimpleModule()
         module.addDeserializer(GregorianCalendar::class.java, DateTimeDeserializer())
 
-        val mapper = ObjectMapper()
-        mapper.dateFormat = SimpleDateFormat("HH:mm:ss zzz dd-MM-yyyy")
-        mapper.registerModule(module)
-        mapper.registerModule(KotlinModule())
-
-        val retrofit = Retrofit.Builder()
-            .client(client.build())
-            .baseUrl(baseUrl)
-            .addConverterFactory(JacksonConverterFactory.create(mapper))
-            .build()
-
-        val service = retrofit.create(MarketApi::class.java)
+        val service = createClient(MarketApi::class.java, module)
         val response = service.lookup(search).execute()
 
         return response.body()?.response?.data
@@ -115,39 +50,10 @@ class Market(private val session: Session,
                      expiryDate: GregorianCalendar?,
                      strike: Float?,
                      distance: Int?): OptionChainResponse? {
-        val keys = OauthKeys(
-            consumerKey = session.consumerKey,
-            consumerSecret = session.consumerSecret,
-            accessToken = session.accessToken,
-            accessSecret = session.accessSecret,
-            verifier = session.verifier
-        )
-
-        val client = OkHttpClient.Builder()
-            .addInterceptor(HttpInterceptor(keys))
-            .addInterceptor(JsonInterceptor())
-            .addInterceptor(ErrorInterceptor())
-
-        if (verbose) {
-            val logger = HttpLoggingInterceptor()
-            logger.level = HttpLoggingInterceptor.Level.BODY
-            client.addInterceptor(logger)
-        }
-
         val module = SimpleModule()
         module.addDeserializer(Instant::class.java, TimestampDeserializer())
 
-        val mapper = ObjectMapper()
-        mapper.registerModule(module)
-        mapper.registerModule(KotlinModule())
-
-        val retrofit = Retrofit.Builder()
-            .client(client.build())
-            .baseUrl(baseUrl)
-            .addConverterFactory(JacksonConverterFactory.create(mapper))
-            .build()
-
-        val service = retrofit.create(MarketApi::class.java)
+        val service = createClient(MarketApi::class.java, module)
         val options = mutableMapOf("symbol" to symbol)
 
         expiryDate?.let {

--- a/src/main/kotlin/connectors/etrade/Service.kt
+++ b/src/main/kotlin/connectors/etrade/Service.kt
@@ -1,0 +1,57 @@
+package com.seansoper.batil.connectors.etrade
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
+
+open class Service(session: Session,
+                   _production: Boolean?,
+                   _verbose: Boolean?,
+                   _baseUrl: String?) {
+
+    private val production = _production ?: false
+    private val verbose = _verbose ?: false
+    private val baseUrl = _baseUrl ?: "https://${(if (production) "api" else "apisb")}.etrade.com"
+
+    private val keys = OauthKeys(
+        consumerKey = session.consumerKey,
+        consumerSecret = session.consumerSecret,
+        accessToken = session.accessToken,
+        accessSecret = session.accessSecret,
+        verifier = session.verifier
+    )
+
+    fun <T> createClient(javaClass: Class<T>, module: SimpleModule? = null): T {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(HttpInterceptor(keys))
+            .addInterceptor(JsonInterceptor())
+            .addInterceptor(ErrorInterceptor())
+
+        if (verbose) {
+            val logger = HttpLoggingInterceptor()
+            logger.level = HttpLoggingInterceptor.Level.BODY
+            client.addInterceptor(logger)
+        }
+
+        val mapper = ObjectMapper()
+
+        module?.let {
+            mapper.registerModule(it)
+        }
+
+        mapper.registerModule(KotlinModule())
+
+        val retrofit = Retrofit.Builder()
+            .client(client.build())
+            .baseUrl(baseUrl)
+            .addConverterFactory(JacksonConverterFactory.create(mapper))
+            .build()
+
+        return retrofit.create(javaClass)
+    }
+
+}

--- a/src/test/resources/apiResponses/accounts/balance.json
+++ b/src/test/resources/apiResponses/accounts/balance.json
@@ -1,0 +1,47 @@
+{
+  "BalanceResponse": {
+    "accountId": "45645298",
+    "accountType": "MARGIN",
+    "optionLevel": "LEVEL_3",
+    "accountDescription": "NAOMI NAGATA",
+    "quoteMode": 0,
+    "dayTraderStatus": "NO_PDT",
+    "accountMode": "MARGIN",
+    "Cash": {
+      "fundsForOpenOrdersCash": 0,
+      "moneyMktBalance": 6934.52
+    },
+    "Computed": {
+      "cashAvailableForInvestment": 7685.52,
+      "cashAvailableForWithdrawal": 7685.52,
+      "totalAvailableForWithdrawal": 7685.52,
+      "netCash": 7685.52,
+      "cashBalance": 0,
+      "settledCashForInvestment": 0,
+      "unSettledCashForInvestment": 0,
+      "fundsWithheldFromPurchasePower": 0,
+      "fundsWithheldFromWithdrawal": 0,
+      "marginBuyingPower": 15371.04,
+      "cashBuyingPower": 7685.52,
+      "dtMarginBuyingPower": 0,
+      "dtCashBuyingPower": 0,
+      "marginBalance": 37388.25,
+      "shortAdjustBalance": 0,
+      "regtEquity": 44322.77,
+      "regtEquityPercent": 100,
+      "accountBalance": 37388.25,
+      "OpenCalls": {
+        "minEquityCall": 0,
+        "fedCall": 0,
+        "cashCall": 0,
+        "houseCall": 0
+      },
+      "RealTimeValues": {
+        "totalAccountValue": 37645.27,
+        "netMv": -6677.5,
+        "netMvLong": 0,
+        "netMvShort": -6677.5
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Significant re-organization of service classes
* Tests for account details endpoint
* Some [add’l fields](https://apisb.etrade.com/docs/api/account/api-balance-v1.html) that were not present in the responses I tested with may need to be supported in a future version.